### PR TITLE
Specify UTF-8 encoding when reading description

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,13 +1,14 @@
 #!/usr/bin/env python
 
+import io
 import os
 import sys
 from setuptools import setup
 from distutils.core import Extension
 from distutils.ccompiler import new_compiler
 
-f = open('README.md')
-long_description = f.read()
+with io.open('README.md', encoding='UTF-8') as f:
+    long_description = f.read()
 
 HOMEPAGE = "https://github.com/sumerc/yappi"
 NAME = "yappi"


### PR DESCRIPTION
Otherwise installation fails on Windows with this error:

```
Collecting git+https://github.com/sumerc/yappi@v0.99
  Cloning https://github.com/sumerc/yappi (to v0.99) to c:\users\bruno\appdata\local\temp\pip-8m31qkuy-build
    Complete output from command python setup.py egg_info:
    Traceback (most recent call last):
      File "<string>", line 1, in <module>
      File "C:\Users\bruno\AppData\Local\Temp\pip-8m31qkuy-build\setup.py", line 10, in <module>
        long_description = f.read()
      File "C:\Users\bruno\AppData\Local\Programs\Python\Python36-32\lib\encodings\cp1252.py", line 23, in decode
        return codecs.charmap_decode(input,self.errors,decoding_table)[0]
    UnicodeDecodeError: 'charmap' codec can't decode byte 0x9d in position 1883: character maps to <undefined>
```