### PR TITLE
Restore blank lines deleted in "merge from bitbucket"

### DIFF
--- a/callstack.c
+++ b/callstack.c
@@ -24,6 +24,7 @@ screate(int size)
         yfree(cs);
         return NULL;
     }
+
     for(i=0; i<size; i++) {
         cs->_items[i].ckey = 0;
         cs->_items[i].t0 = 0;

--- a/hashtab.c
+++ b/hashtab.c
@@ -23,6 +23,7 @@ _hgrow(_htab *ht)
     int i;
     _htab *dummy;
     _hitem *p, *next, *it;
+
     dummy = htcreate(ht->logsize+1);
     if (!dummy)
         return 0;
@@ -102,6 +103,7 @@ hadd(_htab *ht, uintptr_t key, uintptr_t val)
 {
     unsigned int h;
     _hitem *new, *p;
+
     h = HHASH(ht, key);
     p = ht->_table[h];
     new = NULL;
@@ -144,6 +146,7 @@ hfind(_htab *ht, uintptr_t key)
 {
     _hitem *p;
     unsigned int h;
+
     h = HHASH(ht, key);
     p = ht->_table[h];
     while(p) {

--- a/timing.c
+++ b/timing.c
@@ -43,6 +43,7 @@ tickcount(void)
 {
     LARGE_INTEGER li;
     FILETIME ftCreate, ftExit, ftKernel, ftUser;
+
     if (g_clock_type == CPU_CLOCK) {
         GetThreadTimes(GetCurrentThread(), &ftCreate, &ftExit, &ftKernel, &ftUser);
         li.LowPart = ftKernel.dwLowDateTime+ftUser.dwLowDateTime;
@@ -57,6 +58,7 @@ double
 tickfactor(void)
 {
     LARGE_INTEGER li;
+
     if (g_clock_type == WALL_CLOCK) {
         if (QueryPerformanceFrequency(&li)) {
             return 1.0 / li.QuadPart;
@@ -66,6 +68,7 @@ tickfactor(void)
     } else if (g_clock_type == CPU_CLOCK) {
         return 0.0000001;
     }
+
     return 0.0000001; // for suppressing warning: all paths must return a value
 }
 
@@ -75,6 +78,7 @@ long long
 tickcount(void)
 {
     long long rc;
+
     rc = 0;
     if (g_clock_type == CPU_CLOCK) {
         kern_return_t kr;
@@ -85,6 +89,7 @@ tickcount(void)
         tinfo_cnt = THREAD_INFO_MAX;
         kr = thread_info(mach_thread_self(), THREAD_BASIC_INFO, (thread_info_t)tinfo_d, &tinfo_cnt);
         tinfo_b = (thread_basic_info_t)tinfo_d;
+
         if (!(tinfo_b->flags & TH_FLAGS_IDLE))
         {
             rc = (tinfo_b->user_time.seconds + tinfo_b->system_time.seconds);
@@ -108,16 +113,19 @@ long long
 tickcount(void)
 {
     long long rc;
+
     rc = 0; // suppress "may be uninitialized" warning
     if (g_clock_type == CPU_CLOCK) {
 #if defined(USE_CLOCK_TYPE_CLOCKGETTIME)
         struct timespec tp;
+
         clock_gettime(CLOCK_THREAD_CPUTIME_ID, &tp);
         rc = tp.tv_sec;
         rc = rc * 1000000000 + (tp.tv_nsec);
 #elif (defined(USE_CLOCK_TYPE_RUSAGE) && defined(RUSAGE_WHO))
         struct timeval tv;
         struct rusage usage;
+
         getrusage(RUSAGE_WHO, &usage);
         rc = (usage.ru_utime.tv_sec + usage.ru_stime.tv_sec);
         rc = (rc * 1000000) + (usage.ru_utime.tv_usec + usage.ru_stime.tv_usec);
@@ -140,6 +148,7 @@ tickfactor(void)
     } else if (g_clock_type == WALL_CLOCK) {
         return 0.000001;
     }
+
     return 1.0; // suppress "reached end of non-void function" warning
 }
 

--- a/yappi.py
+++ b/yappi.py
@@ -144,6 +144,7 @@ def convert2pstats(stats):
     """
     if not isinstance(stats, YFuncStats):
         raise YappiError("Source stats must be derived from YFuncStats.")
+
     import pstats
     class _PStatHolder:
         def __init__(self, d):
@@ -278,6 +279,7 @@ class YFuncStat(YStat):
         self.ttot += other.ttot
         self.tsub += other.tsub
         self.tavg = self.ttot / self.ncall
+
         for other_child_stat in other.children:
             # all children point to a valid entry, and we shall have merged previous entries by here.
             self.children.append(other_child_stat)
@@ -338,6 +340,7 @@ class YChildFuncStat(YFuncStat):
         self.tsub += other.tsub
         self.tavg = self.ttot / self.ncall
         return self
+
 class YThreadStat(YStat):
     """
     Class holding information for thread stats.
@@ -521,6 +524,7 @@ class YFuncStats(YStatsIndexable):
     _sort_order = None
     _SUPPORTED_LOAD_FORMATS = ['YSTAT']
     _SUPPORTED_SAVE_FORMATS = ['YSTAT', 'CALLGRIND', 'PSTAT']
+
     def __init__(self, files=[]):
         super(YFuncStats, self).__init__()
         self.add(files)
@@ -594,6 +598,7 @@ class YFuncStats(YStatsIndexable):
             saved_stats, saved_clock_type = pickle.load(file)
         except:
             raise YappiError("Unable to load the saved profile information from %s." % (file.name))
+
         # check if we really have some stats to be merged?
         if not self.empty():
             if self._clock_type != saved_clock_type and self._clock_type is not None:
@@ -632,6 +637,7 @@ class YFuncStats(YStatsIndexable):
         """
         _stats = convert2pstats(self)
         _stats.dump_stats(path)
+
     def _save_as_CALLGRIND(self, path):
         """
         Writes all the function stats in a callgrind-style format to the given


### PR DESCRIPTION
0d3b2e17 in #4 has incorrectly resolved whitespace conflicts by deleting blank
lines that were present on both sides of the merge. This restores those lines.