### PR TITLE
Fix Issue54

### DIFF
--- a/doc/api.md
+++ b/doc/api.md
@@ -29,7 +29,22 @@ All results stay in memory unless application (all threads including th
 
 #### `get_func_stats(tag=None, ctx_id=None, filter_callback=None)`
 
-Returns the function stats as a [`YFuncStat`](#yfuncstat) object.
+Returns the function stats as a [`YFuncStat`](#yfuncstat) object. As YAppi is a C extension, it catches the profile data in C API.
+Thus, the profile data collected is buffered until `clear_stats` is called. `get_func_stats` function enumerates the underlying
+buffered data and aggregates the information there. The functions that contain same index id will be aggregated in a single `YFuncStat`
+object. So, if you want to select a specific `tag` or `ctx_id`, you need to select by providing them as arguments to `get_func_stats`.
+Otherwise, data with different `tag`/`ctx_id` will be combined into one `YFuncStat` object. If you really would like to enumerate
+buffered stats in raw, you can use an undocumented function: `_yappi.enum_func_stats(enum_callback, filter_dict)`. You can see
+the usage in `get_func_stats` function.
+
+---
+**Note:**
+
+Filtering `tag` and `ctx_id` are very fast compared to using `filter_callback` since the filtering is completely done on the C extension
+with an internal hash table.
+
+---
+
 
 `tag` retrieves the `YFuncStat` objects having the same `tag` as specified.
 
@@ -57,14 +72,6 @@ stats = yappi.get_func_stats(
 
 There are handy functions that can be used with `filter_callback` to match multiple functions or modules easily.
 See [func_matches](#func_matchesstat-funcs) and [module_matches](#module_matchesstat-modules).
-
----
-**Note:**
-
-`tag` and `ctx_id` are explicitly filtered rather than using `filter_callback`. Filtering `tag` and `ctx_id` are
-very fast compared to using `filter_callback` since the filtering is completely done on the C extension. 
-
----
 
 
 #### `get_thread_stats()`

--- a/run_tests.py
+++ b/run_tests.py
@@ -1,6 +1,16 @@
 import unittest
 import sys
 
+
+def _testsuite_from_tests(tests):
+    suite = unittest.TestSuite()
+    loader = unittest.defaultTestLoader
+    for t in tests:
+        test = loader.loadTestsFromName('tests.%s' % (t))
+        suite.addTest(test)
+    return suite
+
+
 if __name__ == '__main__':
     sys.path.append('tests/')
     test_loader = unittest.defaultTestLoader
@@ -10,7 +20,12 @@ if __name__ == '__main__':
         tests += ['test_asyncio']
     if sys.version_info >= (3, 7):
         tests += ['test_asyncio_context_vars']
-    #tests = ['test_functionality.BasicUsage.test_run_as_script']
     test_suite = test_loader.loadTestsFromNames(tests)
+
+    if len(sys.argv) > 1:
+        test_suite = _testsuite_from_tests(sys.argv[1:])
+
+    #tests = ['test_functionality.BasicUsage.test_run_as_script']
+
     result = test_runner.run(test_suite)
     sys.exit(not result.wasSuccessful())

--- a/tests/test_functionality.py
+++ b/tests/test_functionality.py
@@ -47,14 +47,16 @@ class BasicUsage(utils.YappiUnitTestCase):
 
         yappi.set_tag_callback(_tag_cbk)
         yappi.start()
-        for _ in range(10):
-            a()
+        a()
+        a()
+        a()
         yappi.stop()
         stats = yappi.get_func_stats()
-        self.assertEqual(stats.pop().ncall, 10)  # aggregated if no tag is given
-        for i in range(1, 11):
-            yappi.get_func_stats(tag=i).print_all()
+        self.assertEqual(stats.pop().ncall, 3)  # aggregated if no tag is given
+        stats = yappi.get_func_stats(tag=1)
 
+        for i in range(1, 3):
+            stats = yappi.get_func_stats(tag=i)
             stats = yappi.get_func_stats(
                 tag=i, filter_callback=lambda x: yappi.func_matches(x, [a])
             )

--- a/tests/test_functionality.py
+++ b/tests/test_functionality.py
@@ -50,12 +50,14 @@ class BasicUsage(utils.YappiUnitTestCase):
         for _ in range(10):
             a()
         yappi.stop()
-        for i in range(10):
+        stats = yappi.get_func_stats()
+        self.assertEqual(stats.pop().ncall, 10)  # aggregated if no tag is given
+        for i in range(1, 11):
             stats = yappi.get_func_stats(
                 tag=i, filter_callback=lambda x: yappi.func_matches(x, [a])
             )
             stat = stats.pop()
-            self.assertTrue(stat.ncall, 1)
+            self.assertEqual(stat.ncall, 1)
 
         yappi.set_tag_callback(None)
         yappi.clear_stats()
@@ -63,9 +65,9 @@ class BasicUsage(utils.YappiUnitTestCase):
         b()
         b()
         stats = yappi.get_func_stats()
-        self.assertTrue(len(stats), 1)
+        self.assertEqual(len(stats), 1)
         stat = stats.pop()
-        self.assertTrue(stat.ncall, 2)
+        self.assertEqual(stat.ncall, 2)
 
     def test_filter(self):
 

--- a/tests/test_functionality.py
+++ b/tests/test_functionality.py
@@ -53,9 +53,12 @@ class BasicUsage(utils.YappiUnitTestCase):
         stats = yappi.get_func_stats()
         self.assertEqual(stats.pop().ncall, 10)  # aggregated if no tag is given
         for i in range(1, 11):
+            yappi.get_func_stats(tag=i).print_all()
+
             stats = yappi.get_func_stats(
                 tag=i, filter_callback=lambda x: yappi.func_matches(x, [a])
             )
+
             stat = stats.pop()
             self.assertEqual(stat.ncall, 1)
 
@@ -134,10 +137,10 @@ class BasicUsage(utils.YappiUnitTestCase):
 
         # invalid filters`
         self.assertRaises(
-            TypeError, yappi.get_func_stats, filter={'tag': "sss"}
+            Exception, yappi.get_func_stats, filter={'tag': "sss"}
         )
         self.assertRaises(
-            TypeError, yappi.get_func_stats, filter={'ctx_id': "None"}
+            Exception, yappi.get_func_stats, filter={'ctx_id': "None"}
         )
 
     def test_filter_callback(self):

--- a/tests/test_functionality.py
+++ b/tests/test_functionality.py
@@ -9,6 +9,8 @@ import utils
 import multiprocessing  # added to fix http://bugs.python.org/issue15881 for > Py2.6
 import subprocess
 
+_counter = 0
+
 
 class BasicUsage(utils.YappiUnitTestCase):
 
@@ -29,6 +31,41 @@ class BasicUsage(utils.YappiUnitTestCase):
         yappi.set_tag_callback(_unsigned_overflow_margin)
         yappi.start()
         foo()
+
+    def test_issue54(self):
+
+        def _tag_cbk():
+            global _counter
+            _counter += 1
+            return _counter
+
+        def a():
+            pass
+
+        def b():
+            pass
+
+        yappi.set_tag_callback(_tag_cbk)
+        yappi.start()
+        for _ in range(10):
+            a()
+        yappi.stop()
+        for i in range(10):
+            stats = yappi.get_func_stats(
+                tag=i, filter_callback=lambda x: yappi.func_matches(x, [a])
+            )
+            stat = stats.pop()
+            self.assertTrue(stat.ncall, 1)
+
+        yappi.set_tag_callback(None)
+        yappi.clear_stats()
+        yappi.start()
+        b()
+        b()
+        stats = yappi.get_func_stats()
+        self.assertTrue(len(stats), 1)
+        stat = stats.pop()
+        self.assertTrue(stat.ncall, 2)
 
     def test_filter(self):
 
@@ -92,6 +129,14 @@ class BasicUsage(utils.YappiUnitTestCase):
         yappi.stop()
         fstats = yappi.get_func_stats(filter={"module": "time"})
         self.assertEqual(len(fstats), 1)
+
+        # invalid filters`
+        self.assertRaises(
+            TypeError, yappi.get_func_stats, filter={'tag': "sss"}
+        )
+        self.assertRaises(
+            TypeError, yappi.get_func_stats, filter={'ctx_id': "None"}
+        )
 
     def test_filter_callback(self):
 

--- a/yappi/_yappi.c
+++ b/yappi/_yappi.c
@@ -177,7 +177,7 @@ static _ctx * _profile_thread(PyThreadState *ts);
 static int _pitenumdel(_hitem *item, void *arg);
 
 // funcs
-/*
+
 static void _DebugPrintObjects(unsigned int arg_count, ...)
 {
     unsigned int i;
@@ -189,7 +189,7 @@ static void _DebugPrintObjects(unsigned int arg_count, ...)
     }
     printf("\n");
     va_end(vargs);
-} */
+}
 
 int IS_ASYNC(PyFrameObject *frame)
 {
@@ -879,10 +879,10 @@ _call_enter(PyObject *self, PyFrameObject *frame, PyObject *arg, int ccall)
     _pit_children_info *pci;
     uintptr_t current_tag;
 
-    //printf("call ENTER:%s %s\n", PyStr_AS_CSTRING(frame->f_code->co_filename),
-    //                             PyStr_AS_CSTRING(frame->f_code->co_name));
-
     current_tag = _current_tag();
+
+    //printf("call ENTER:%s %s %d\n", PyStr_AS_CSTRING(frame->f_code->co_filename),
+    //                             PyStr_AS_CSTRING(frame->f_code->co_name), current_tag);
 
     if (ccall) {
         cp = _ccode2pit((PyCFunctionObject *)arg, current_tag);
@@ -1481,7 +1481,6 @@ _pitenumstat(_hitem *item, void *arg)
     PyObject *children;
     _pit_children_info *pci;
     _ctxfuncenumarg *eargs;
-    //uintptr_t tag;
 
     children = NULL;
     pt = (_pit *)item->val;
@@ -1519,11 +1518,6 @@ _pitenumstat(_hitem *item, void *arg)
         pt->tsubtotal = 0;
     if (pt->callcount == 0)
         pt->callcount = 1;
-
-    // tag = 0;
-    // if (eargs->enum_args->func_filter.tag) {
-    //     tag = PyLong_AsVoidPtr(eargs->enum_args->func_filter.tag);
-    // }
 
     exc = PyObject_CallFunction(eargs->enum_args->enumfn, "((OOkkkIffIOkOkO))", 
                         pt->name, pt->modname, pt->lineno, pt->callcount,
@@ -1627,6 +1621,7 @@ _filterdict_to_statfilter(PyObject *filter_dict, _fast_func_stat_filter* filter)
         PyLong_AsVoidPtr(fv);
         if (PyErr_Occurred()) {
             yerr("invalid tag passed to get_func_stats.");
+            filter->tag = NULL;
             return 0;
         }
         filter->tag = fv;
@@ -1636,6 +1631,7 @@ _filterdict_to_statfilter(PyObject *filter_dict, _fast_func_stat_filter* filter)
         PyLong_AsVoidPtr(fv);
         if (PyErr_Occurred()) {
             yerr("invalid ctx_id passed to get_func_stats.");
+            filter->ctx_id = NULL;
             return 0;
         }
         filter->ctx_id = fv;

--- a/yappi/_yappi.c
+++ b/yappi/_yappi.c
@@ -229,7 +229,7 @@ _log_err(unsigned int code)
 }
 
 static _pit *
-_create_pit()
+_create_pit(void)
 {
     _pit *pit;
 

--- a/yappi/yappi.py
+++ b/yappi/yappi.py
@@ -150,13 +150,14 @@ def module_matches(stat, modules):
             "Argument 'stat' shall be a YStat object. (%s)" % (stat)
         )
 
-    if not len(modules):
-        raise YappiError("Argument 'modules' cannot be empty.")
-
     if not isinstance(modules, list):
         raise YappiError(
             "Argument 'modules' is not a list object. (%s)" % (modules)
         )
+
+    if not len(modules):
+        raise YappiError("Argument 'modules' cannot be empty.")
+
     if stat.full_name not in _fn_descriptor_dict:
         return False
 
@@ -180,13 +181,13 @@ def func_matches(stat, funcs):
             "Argument 'stat' shall be a YStat object. (%s)" % (stat)
         )
 
-    if not len(funcs):
-        raise YappiError("Argument 'funcs' cannot be empty.")
-
     if not isinstance(funcs, list):
         raise YappiError(
             "Argument 'funcs' is not a list object. (%s)" % (funcs)
         )
+
+    if not len(funcs):
+        raise YappiError("Argument 'funcs' cannot be empty.")
 
     if stat.full_name not in _fn_descriptor_dict:
         return False

--- a/yappi/yappi.py
+++ b/yappi/yappi.py
@@ -1076,7 +1076,7 @@ def start(builtins=False, profile_threads=True):
     _yappi.start(builtins, profile_threads)
 
 
-def get_func_stats(tag=None, ctx_id=None, filter={}, filter_callback=None):
+def get_func_stats(tag=None, ctx_id=None, filter=None, filter_callback=None):
     """
     Gets the function profiler results with given filters and returns an iterable.
 
@@ -1091,8 +1091,13 @@ def get_func_stats(tag=None, ctx_id=None, filter={}, filter_callback=None):
     maybe, but simply that is not worth the effort for an extra filter() call. Maybe
     in the future.
     """
-    tag = filter.get('tag', tag)
-    ctx_id = filter.get('ctx_id', tag)
+    if not filter:
+        filter = {}
+
+    if tag:
+        filter['tag'] = tag
+    if ctx_id:
+        filter['ctx_id'] = ctx_id
 
     # multiple invocation pause/resume is allowed. This is needed because
     # not only get() is executed here.


### PR DESCRIPTION
- `get_func_stats()` canot accept `tag`+`ctx_id` as params.
- `get_func_stats` `filter` is an empty dict as default value which might lead to error on subsequent calls.