### PR TITLE
Fix function type signature and sentinel in method table

### DIFF
--- a/yappi/_yappi.c
+++ b/yappi/_yappi.c
@@ -1736,7 +1736,7 @@ start(PyObject *self, PyObject *args)
 }
 
 static PyObject*
-stop(PyObject *self)
+stop(PyObject *self, PyObject *args)
 {
     _stop();
     Py_RETURN_NONE;
@@ -2090,13 +2090,13 @@ _resume(PyObject *self, PyObject *args)
             // error
             return NULL;
     }
-    
+
     Py_RETURN_NONE;
 }
 
 static PyMethodDef yappi_methods[] = {
     {"start", start, METH_VARARGS, NULL},
-    {"stop", (PyCFunction)stop, METH_NOARGS, NULL},
+    {"stop", stop, METH_NOARGS, NULL},
     {"enum_func_stats", enum_func_stats, METH_VARARGS, NULL},
     {"enum_context_stats", enum_context_stats, METH_VARARGS, NULL},
     {"enum_thread_stats", enum_context_stats, METH_VARARGS, NULL},
@@ -2117,7 +2117,7 @@ static PyMethodDef yappi_methods[] = {
     {"_profile_event", profile_event, METH_VARARGS, NULL}, // for internal usage.
     {"_pause", _pause, METH_VARARGS, NULL}, // for internal usage.
     {"_resume", _resume, METH_VARARGS, NULL}, // for internal usage.
-    {NULL, NULL}      /* sentinel */
+    {NULL, NULL, 0, NULL}      /* sentinel */
 };
 
 #ifdef IS_PY3K


### PR DESCRIPTION
This commit fixes two method table issues.

First, it fixes the type signature of the "stop" function, otherwise, as far as I know, undefined behavior is invoked (and may or may not cause weird things immediately).

Second, it fixes the sentinel of the method table, as described in [1] and [2].

[1] https://docs.python.org/2.7/extending/extending.html#the-module-s-method-table-and-initialization-function
[2] https://docs.python.org/3/extending/extending.html#the-module-s-method-table-and-initialization-function