### PR TITLE
Fix tavg and avgtime sort types pointing to the wrong YFuncStat key.

### DIFF
--- a/yappi/yappi.py
+++ b/yappi/yappi.py
@@ -46,11 +46,11 @@ SORT_TYPES_FUNCSTATS = {
     "callcount": 3,
     "totaltime": 6,
     "subtime": 7,
-    "avgtime": 10,
+    "avgtime": 14,
     "ncall": 3,
     "ttot": 6,
     "tsub": 7,
-    "tavg": 10
+    "tavg": 14
 }
 SORT_TYPES_CHILDFUNCSTATS = {
     "name": 10,


### PR DESCRIPTION
Closes #87. The `tavg` key [here](https://github.com/sumerc/yappi/blob/master/yappi/yappi.py#L446) is 14, not 10 (`ctx_id`) which was previously written.