### PR TITLE
Use `PyEval_GetLocals` for getting locals in Python `3.10` and up

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        python-version: [2.7, 3.5, 3.6, 3.7, 3.8, 3.9, "3.10"]
+        python-version: [2.7, 3.6, 3.7, 3.8, 3.9, "3.10"]
         exclude:
           - os: windows-latest
             python-version: 2.7 # error: Microsoft Visual C++ 9.0 is required

--- a/tests/test_functionality.py
+++ b/tests/test_functionality.py
@@ -1176,6 +1176,7 @@ class MultithreadedScenarios(utils.YappiUnitTestCase):
         c.join()
         a()
         stats = yappi.get_func_stats()
+        stats.print_all()
         fsa1 = utils.find_stat_by_name(stats, 'Worker1.a')
         fsa2 = utils.find_stat_by_name(stats, 'a')
         self.assertTrue(fsa1 is not None)

--- a/tests/test_functionality.py
+++ b/tests/test_functionality.py
@@ -1176,7 +1176,6 @@ class MultithreadedScenarios(utils.YappiUnitTestCase):
         c.join()
         a()
         stats = yappi.get_func_stats()
-        stats.print_all()
         fsa1 = utils.find_stat_by_name(stats, 'Worker1.a')
         fsa2 = utils.find_stat_by_name(stats, 'a')
         self.assertTrue(fsa1 is not None)


### PR DESCRIPTION
`PyFrame_FastToLocals` is public but not an undocumented function and gives [weird results](#97) in `3.10` and up. 

Fixes #97