### PR TITLE
Add dependabot to create PR for GHA updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"


### PR DESCRIPTION
Ensures the Github Actions versions here https://github.com/sumerc/yappi/tree/master/.github/workflows are up to date.