### PR TITLE
Remove support of Python 2.7

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,10 +16,8 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        python-version: [2.7, 3.7, 3.8, 3.9, "3.10", 3.11.0]
+        python-version: [3.7, 3.8, 3.9, "3.10", 3.11.0]
         exclude:
-          - os: windows-latest
-            python-version: 2.7 # error: Microsoft Visual C++ 9.0 is required
           # - os: macos-latest
           #   python-version: 3.9 # TODO: getting Illegal instruction somehow
 

--- a/setup.py
+++ b/setup.py
@@ -49,7 +49,6 @@ CLASSIFIERS = [
     'Intended Audience :: Developers',
     'License :: OSI Approved :: MIT License',
     'Programming Language :: Python',
-    'Programming Language :: Python :: 2.7',
     'Programming Language :: Python :: 3.5',
     'Programming Language :: Python :: 3.6',
     'Programming Language :: Python :: 3.7',


### PR DESCRIPTION
Python2 is EOL since Jan 1 2020 [1]

[1] https://www.python.org/doc/sunset-python-2/