### PR TITLE
Store IDs of child functions in the callgrind output

### DIFF
--- a/yappi/yappi.py
+++ b/yappi/yappi.py
@@ -942,6 +942,17 @@ class YFuncStats(YStatsIndexable):
                 )
             ]
 
+            # children ids
+            for child in func_stat.children:
+                file_ids += ['fl=(%d) %s' % (child.index, child.module)]
+                func_ids += [
+                'fn=(%d) %s %s:%s' % (
+                    child.index, child.name, child.module,
+                    child.lineno
+                )
+            ]
+            
+
         lines += file_ids + func_ids
 
         # add stats for each function we have a record of

--- a/yappi/yappi.py
+++ b/yappi/yappi.py
@@ -933,6 +933,7 @@ class YFuncStats(YStatsIndexable):
         # add function definitions
         file_ids = ['']
         func_ids = ['']
+        func_idx_list = []
         for func_stat in self:
             file_ids += ['fl=(%d) %s' % (func_stat.index, func_stat.module)]
             func_ids += [
@@ -941,18 +942,22 @@ class YFuncStats(YStatsIndexable):
                     func_stat.lineno
                 )
             ]
-
-            # children ids
+            func_idx_list.append(func_stat.index)
+            
+            # also adds function information for children
             for child in func_stat.children:
+                # ... but make sure to add each function only once
+                if child.index in func_idx_list:
+                    continue
                 file_ids += ['fl=(%d) %s' % (child.index, child.module)]
                 func_ids += [
-                'fn=(%d) %s %s:%s' % (
-                    child.index, child.name, child.module,
-                    child.lineno
-                )
-            ]
+                    'fn=(%d) %s %s:%s' % (
+                        child.index, child.name, child.module,
+                        child.lineno
+                    )
+                ]
+                func_idx_list.append(child.index)
             
-
         lines += file_ids + func_ids
 
         # add stats for each function we have a record of


### PR DESCRIPTION
This fixes #95.  Only touches a few lines in `yappi.py` and should be pretty much uncontroversial. 

Let me know if you need anything to be changed for merging this. 
