### PR TITLE
Remove Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,0 @@
-language: python
-os:
-  - linux
-python:
-  - "3.10-dev"
-script:
-  - pip install .[test] || true
-  - python setup.py install # todo: pip install fails on 3.10
-  - python run_tests.py

--- a/README.md
+++ b/README.md
@@ -8,7 +8,6 @@
 </p>
 
 <p align="center">
-    <img src="https://www.travis-ci.org/sumerc/yappi.svg?branch=master">
     <img src="https://github.com/sumerc/yappi/workflows/CI/badge.svg?branch=master">
     <img src="https://img.shields.io/pypi/v/yappi.svg">
     <img src="https://img.shields.io/pypi/dw/yappi.svg">


### PR DESCRIPTION
Remove the config and badge for Travis CI, it's [stopped working](https://app.travis-ci.com/github/sumerc/yappi) and this project is well tested with [GitHub Actions](https://github.com/sumerc/yappi/actions).