### PR TITLE
README: Add useful links to badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,12 +10,12 @@
 [![FreePalestine.Dev](https://freepalestine.dev/header/1)](https://freepalestine.dev)
 
 <p align="center">
-    <img src="https://github.com/sumerc/yappi/workflows/CI/badge.svg?branch=master">
-    <img src="https://img.shields.io/pypi/v/yappi.svg">
-    <img src="https://img.shields.io/pypi/dw/yappi.svg">
-    <img src="https://img.shields.io/pypi/pyversions/yappi.svg">
-    <img src="https://img.shields.io/github/last-commit/sumerc/yappi.svg">
-    <img src="https://img.shields.io/github/license/sumerc/yappi.svg">
+    <a href="https://github.com/sumerc/yappi/actions/workflows/main.yml"><img src="https://github.com/sumerc/yappi/workflows/CI/badge.svg?branch=master"></a>
+    <a href="https://pypi.org/project/yappi/"><img src="https://img.shields.io/pypi/v/yappi.svg"></a>
+    <a href="https://pypi.org/project/yappi/"><img src="https://img.shields.io/pypi/dw/yappi.svg"></a>
+    <a href="https://pypi.org/project/yappi/"><img src="https://img.shields.io/pypi/pyversions/yappi.svg"></a>
+    <a href="https://github.com/sumerc/yappi/commits/"><img src="https://img.shields.io/github/last-commit/sumerc/yappi.svg"></a>
+    <a href="https://github.com/sumerc/yappi/blob/master/LICENSE"><img src="https://img.shields.io/github/license/sumerc/yappi.svg"></a>
     <a href="https://freepalestine.dev"><img src="https://freepalestine.dev/badge?t=d&u=0&r=1" alt="From the river to the sea, Palestine will be free" /></a>
 </p>
 


### PR DESCRIPTION
Right now, the badges just link to their badge image.

Instead, link to an appropriate destination.