### PR TITLE
Add support for python 3.13

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,6 +14,9 @@ jobs:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
         python-version: [3.7, 3.8, 3.9, "3.10", "3.11", "3.12"]
+        exclude:
+          - os: macos-latest
+            python-version: 3.7
 
     steps:
     - uses: actions/checkout@v4

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -72,7 +72,7 @@ class YappiUnitTestCase(unittest.TestCase):
     ):
         # time sensitive tests fail on MacOS CI, increase threshold
         if sys.platform == 'darwin':
-            positive_err = 1.5
+            positive_err = 1.8
             negative_err = 0.6
 
         pos_epsilon = (x * positive_err)

--- a/yappi/_yappi.c
+++ b/yappi/_yappi.c
@@ -1284,7 +1284,9 @@ _resume_greenlet_ctx(_ctx *ctx)
 static void 
 _eval_setprofile(PyThreadState *ts)
 {
-#if PY_VERSION_HEX > 0x030b0000
+#if PY_VERSION_HEX > 0x030c0000
+    PyEval_SetProfileAllThreads(_yapp_callback, NULL);
+#elif PY_VERSION_HEX > 0x030b0000
     _PyEval_SetProfile(ts, _yapp_callback, NULL);
 #elif PY_VERSION_HEX < 0x030a00b1
     ts->use_tracing = 1;
@@ -1298,7 +1300,9 @@ _eval_setprofile(PyThreadState *ts)
 static void
 _eval_unsetprofile(PyThreadState *ts)
 {
-#if PY_VERSION_HEX > 0x030b0000
+#if PY_VERSION_HEX > 0x030c0000
+    PyEval_SetProfileAllThreads(NULL, NULL);
+#elif PY_VERSION_HEX > 0x030b0000
     _PyEval_SetProfile(ts, NULL, NULL);
 #elif PY_VERSION_HEX < 0x030a00b1
     ts->use_tracing = 0;


### PR DESCRIPTION
_PyEval_SetProfile() has been moved to internal pycore_ceval.h and it is not longer exported [1]

[1] https://github.com/python/cpython/commit/c494fb333b57bdf43fc90189fc29a00c293b2987