### PR TITLE
Fix build for Python 3.14

### DIFF
--- a/yappi/_yappi.c
+++ b/yappi/_yappi.c
@@ -13,6 +13,12 @@
 #error "Yappi requires long longs!"
 #endif
 
+#if PY_VERSION_HEX >= 0x030E0000  // Python 3.14+
+  #ifndef Py_BUILD_CORE
+    #define Py_BUILD_CORE
+  #endif
+  #include "internal/pycore_genobject.h"
+#endif
 #include "bytesobject.h"
 #include "frameobject.h"
 #include "callstack.h"


### PR DESCRIPTION
struct _PyGenObject has been moved to internal/pycore_genobject.h,
causing a build failure with Python 3.14rc3
