### PR TITLE
Fix: `twine check` failures

### DIFF
--- a/.github/workflows/github-deploy.yml
+++ b/.github/workflows/github-deploy.yml
@@ -65,7 +65,8 @@ jobs:
           merge-multiple: true
           path: dist
 
-      - uses: pypa/gh-action-pypi-publish@v1.8.14
+      - uses: pypa/gh-action-pypi-publish@v1.13.0
         with:
+          verbose: true
           user: __token__
           password: ${{ secrets.pypi_password }}


### PR DESCRIPTION
Fix [publish step](https://github.com/sumerc/yappi/actions/runs/18773536531/job/53563524259) errors.