### PR TITLE
Fix file reading in yappi.py to use UTF-8 encoding

### DIFF
--- a/yappi/yappi.py
+++ b/yappi/yappi.py
@@ -1498,7 +1498,7 @@ def main():
         start(options.profile_builtins, not options.profile_single_thread)
         try:
             exec(
-                compile(open(sys.argv[0]).read(), sys.argv[0], 'exec'),
+                compile(open(sys.argv[0], encoding='utf8').read(), sys.argv[0], 'exec'),
                 sys._getframe(1).f_globals,
                 sys._getframe(1).f_locals
             )


### PR DESCRIPTION
Fix https://github.com/sumerc/yappi/issues/202.

Since all python files are utf8 now, `encoding="utf8"` is good